### PR TITLE
Implement Test & update schema file for music

### DIFF
--- a/database/schema.sql
+++ b/database/schema.sql
@@ -21,3 +21,15 @@ CREATE TABLE authors (
   last_name VARCHAR(50) NOT NULL
 );
 
+CREATE TABLE music_albums (
+  item_id INTEGER PRIMARY KEY,
+  archived BOOLEAN,
+  on_spotify BOOLEAN,
+  CONSTRAINT fk_music_items FOREIGN KEY (item_id) REFERENCES items(id)
+  CONSTRAINT fk_music_genre  FOREIGN key (genre_id) REFERENCES genres(id)
+);
+
+CREATE TABLE genres (
+  id SERIAL PRIMARY KEY,
+  name VARCHAR(255) NOT NULL
+);

--- a/spec/genre_spec.rb
+++ b/spec/genre_spec.rb
@@ -1,0 +1,32 @@
+require_relative '../src/genre'
+
+describe Genre do
+  let(:name) { 'Rock' }
+
+  subject { described_class.new(name) }
+
+  describe '#initialize' do
+    it 'sets the name correctly' do
+      expect(subject.name).to eq(name)
+    end
+
+    it 'generates a random id' do
+      expect(subject.id).to be_an(Integer)
+    end
+
+    it 'initializes items as an empty array' do
+      expect(subject.items).to be_empty
+    end
+  end
+
+  describe '#add_item' do
+    it 'adds an item to the genre and sets genre for the item' do
+      item = double('Item')
+      expect(item).to receive(:add_genre).with(subject)
+
+      subject.add_item(item)
+
+      expect(subject.items).to include(item)
+    end
+  end
+end

--- a/spec/music_album_spec.rb
+++ b/spec/music_album_spec.rb
@@ -1,0 +1,26 @@
+require_relative '../src/music_album'
+require_relative '../src/genre'
+
+describe MusicAlbum do
+  describe '#archived' do
+    context 'when on_spotify is true' do
+      it 'returns true for an album that can be archived' do
+        music_album = described_class.new(true, '1999')
+        expect(music_album.archived).to be(false)
+      end
+
+      it 'returns false for an album that cannot be archived' do
+        new_publish_date = '2023'
+        music_album = described_class.new(true, new_publish_date)
+        expect(music_album.archived).to be(false)
+      end
+    end
+
+    context 'when on_spotify is false' do
+      it 'returns false regardless of release year' do
+        music_album = described_class.new(false, '1999')
+        expect(music_album.archived).to be(false)
+      end
+    end
+  end
+end


### PR DESCRIPTION
In this PR:
- Implement Test for music album & genre 
- Create a table for a music album and genre in schema.sql file.